### PR TITLE
Add `HeightRound` for round representation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,6 @@ pub use key::Key;
 pub use message::Message;
 pub use network::{Consensus, Network};
 pub use node::Node;
-pub use round::Round;
+pub use round::HeightRound;
 pub use state::State;
 pub use validator::ValidatorId;

--- a/src/message.rs
+++ b/src/message.rs
@@ -1,16 +1,15 @@
-use crate::{Block, Key, Round, State, ValidatorId};
+use crate::{Block, HeightRound, Key, State, ValidatorId};
 
 pub trait Message {
     type Block: Block;
     type Key: Key;
-    type Round: Round;
     type ValidatorId: ValidatorId;
 
-    fn new(round: Self::Round, key: Self::Key, state: State, block: Self::Block) -> Self;
+    fn new(round: HeightRound, key: Self::Key, state: State, block: Self::Block) -> Self;
 
     fn block(&self) -> &Self::Block;
     fn owned_block(&self) -> Self::Block;
-    fn round(&self) -> Self::Round;
+    fn round(&self) -> &HeightRound;
     fn state(&self) -> State;
 
     /// Author of the message

--- a/src/network.rs
+++ b/src/network.rs
@@ -1,4 +1,4 @@
-use crate::{Block, Message, Round, ValidatorId};
+use crate::{Block, HeightRound, Message, ValidatorId};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[repr(u8)]
@@ -30,23 +30,53 @@ pub trait Network {
     type Block: Block<Payload = Self::Payload>;
     type Message: Message<ValidatorId = Self::ValidatorId>;
     type Payload;
-    type Round: Round;
     type ValidatorId: ValidatorId;
+    type ValidatorIdRef: AsRef<Self::ValidatorId>;
+    type ValidatorIdSorted: Iterator<Item = Self::ValidatorIdRef>;
 
     fn broadcast(&mut self, message: &Self::Message);
-    fn increment_round(round: Self::Round) -> Self::Round;
-    fn is_validator(&self, round: Self::Round, validator: &Self::ValidatorId) -> bool;
-    fn validators(&self, round: Self::Round) -> usize;
-    fn leader(&self, round: Self::Round) -> Option<&Self::ValidatorId>;
+    fn validators_sorted(&self, round: &HeightRound) -> Self::ValidatorIdSorted;
 
     /// Generate the block payload to allow the creation of a new block.
     fn block_payload(&self) -> Self::Payload;
 
+    fn leader(&self, round: &HeightRound) -> Option<Self::ValidatorIdRef> {
+        let count = self.validators_count(round) as u64;
+
+        (count > 0)
+            .then(|| {
+                let h = round.height();
+                let r = round.round();
+
+                let index = (h + r) % count;
+
+                self.validators_sorted(round).skip(index as usize).next()
+            })
+            .flatten()
+    }
+
+    fn is_validator(&self, round: &HeightRound, validator: &Self::ValidatorId) -> bool {
+        self.validators_sorted(round)
+            .any(|p| p.as_ref() == validator)
+    }
+
+    fn validators_count(&self, round: &HeightRound) -> usize {
+        self.validators_sorted(round).count()
+    }
+
+    fn increment_height(round: HeightRound) -> HeightRound {
+        round.increment_height()
+    }
+
+    fn increment_round(round: HeightRound) -> HeightRound {
+        round.increment_round()
+    }
+
     /// From a round and a count of positive voters, resolves the consensus state.
     ///
     /// Will not evaluate negative voters because this is handled by the protocol timeout.
-    fn consensus(&self, round: Self::Round, count: usize) -> Consensus {
-        let validators = self.validators(round);
+    fn consensus(&self, round: &HeightRound, count: usize) -> Consensus {
+        let validators = self.validators_count(round);
 
         let minimum = validators > 3;
         let consensus = validators * 2 / 3;

--- a/src/round.rs
+++ b/src/round.rs
@@ -1,22 +1,76 @@
-pub trait Round: Copy {}
+use core::cmp::Ordering;
+use core::fmt;
 
-macro_rules! impl_round {
-    ($t:ty) => {
-        impl Round for $t {}
-        impl Round for ($t, $t) {}
-        impl Round for ($t, $t, $t) {}
-        impl Round for ($t, $t, $t, $t) {}
-    };
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct HeightRound {
+    height: u64,
+    round: u64,
 }
 
-impl_round!(usize);
-impl_round!(u8);
-impl_round!(u16);
-impl_round!(u32);
-impl_round!(u64);
-impl_round!(u128);
-impl_round!(i8);
-impl_round!(i16);
-impl_round!(i32);
-impl_round!(i64);
-impl_round!(i128);
+impl PartialOrd for HeightRound {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.height
+            .partial_cmp(&other.height)
+            .map(|o| match o {
+                Ordering::Equal => self.round.partial_cmp(&other.round),
+
+                _ => Some(o),
+            })
+            .flatten()
+    }
+}
+
+impl Ord for HeightRound {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.height.cmp(&other.height) {
+            Ordering::Less => Ordering::Less,
+            Ordering::Greater => Ordering::Greater,
+
+            _ => self.round.cmp(&other.round),
+        }
+    }
+}
+
+impl fmt::Display for HeightRound {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "HeightRound({}, {})", self.height, self.round)
+    }
+}
+
+impl HeightRound {
+    pub const fn new(height: u64, round: u64) -> Self {
+        Self { height, round }
+    }
+
+    pub const fn start(height: u64) -> Self {
+        Self::new(height, 0)
+    }
+
+    pub const fn height(&self) -> u64 {
+        self.height
+    }
+
+    pub const fn round(&self) -> u64 {
+        self.round
+    }
+
+    pub const fn increment_height(self) -> Self {
+        Self {
+            height: self.height + 1,
+            round: 0,
+        }
+    }
+
+    pub const fn increment_round(self) -> Self {
+        Self {
+            height: self.height,
+            round: self.round + 1,
+        }
+    }
+}
+
+impl From<u64> for HeightRound {
+    fn from(height: u64) -> Self {
+        Self::start(height)
+    }
+}

--- a/tests/mock/Cargo.toml
+++ b/tests/mock/Cargo.toml
@@ -12,5 +12,6 @@ elliptic-curve = "0.11"
 k256 = { version = "0.10", features = [ "arithmetic", "ecdsa" ] }
 fuel-pbft = { path = "../../" }
 hex = "0.4"
+itertools = "0.10"
 rand = "0.8"
 sha2 = "0.10"


### PR DESCRIPTION
This implementation aims to be closer to Tendermint. There, the round
implementation isn't generic and is always a tuple (height, round).

This provides the ability to perform concrete implementations for some
parts of the consensus, such as the leader election per round. In
Tendermint, it is performed as a round-robin of the leaders.

The library will run a round-robin per height over a list of sorted
validators. The list of sorted validators must be provided by the
implementor, and the sorting strategy is considered an implementation
detail.

It can and is expected that the implementor optimizes and cache the
sorted validators so this list can be sorted efficiently. This will be
an associated type of the network trait, so its internal logic can
assume the sorting is solved by an efficient algorithm.

The implementor can overwrite any of these implementations with more
efficient or convenient implementations, when applicable.