### PR TITLE
Add Stake and StakePool structs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ description = "A Rust implementation of the Tendermint consensus protocol."
 async-trait = "0.1"
 fuel-crypto = { version = "0.4", default-features = false }
 fuel-types = { version = "0.3", default-features = false }
+hashbrown = "0.12"
 rand = { version = "0.8", default-features = false, optional = true, features = [ "std_rng" ] }
 time = { version = "0.3", default-features = false }
 tokio = { version = "1.17", optional = true, features = [ "rt", "sync", "time" ] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,3 +1,5 @@
+use crate::Height;
+
 use core::convert::Infallible;
 use core::fmt;
 
@@ -6,6 +8,14 @@ use core::fmt;
 pub enum Error {
     /// The block validation failed
     BlockValidation,
+
+    /// An intersecting stake cannot be added to the list.
+    DuplicatedStake {
+        /// Initial height of the conflicting stake.
+        height: Height,
+        /// The conflicting stake will be valid before this height.
+        valid_before: Height,
+    },
 
     /// Failed to define elapsed time since genesis
     ElapsedTimeFailure,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ pub use error::Error;
 pub use keychain::Keychain;
 pub use moderator::Moderator;
 pub use reactor::{Config, Event, Message, Notification, Reactor, Request, Response};
-pub use stake::{Stake, StakePool};
+pub use stake::{Stake, ValidatorStakes};
 pub use step::Step;
 pub use vote::Vote;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ mod keychain;
 mod metadata;
 mod moderator;
 mod reactor;
+mod stake;
 mod step;
 mod vote;
 
@@ -38,6 +39,7 @@ pub use error::Error;
 pub use keychain::Keychain;
 pub use moderator::Moderator;
 pub use reactor::{Config, Event, Message, Notification, Reactor, Request, Response};
+pub use stake::{Stake, StakePool};
 pub use step::Step;
 pub use vote::Vote;
 

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -125,8 +125,7 @@ impl Reactor {
         let leader = self
             .metadata
             .validators_at_height(height)
-            .skip(index as usize)
-            .next()
+            .nth(index as usize)
             .ok_or(Error::ValidatorNotFound)?;
 
         #[cfg(feature = "trace")]
@@ -342,7 +341,7 @@ impl Reactor {
             proposed_step
         );
 
-        if !self.metadata.validate::<K>(&vote).is_ok() {
+        if self.metadata.validate::<K>(&vote).is_err() {
             #[cfg(feature = "trace")]
             tracing::trace!(
                 "dropping received invalid vote - height {}, round {}, author {:08x}, step: {:?}",

--- a/src/stake.rs
+++ b/src/stake.rs
@@ -16,7 +16,7 @@ use stake_keys::StakeKeys;
 /// signatures with the chosen protocol.
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Stake {
-    /// One-time key for a height range
+    /// Hot key for a height range
     pub key: PublicKey,
     /// Staked value
     pub value: u64,

--- a/src/stake.rs
+++ b/src/stake.rs
@@ -6,9 +6,9 @@ use hashbrown::HashMap;
 
 use core::ops::{Range, RangeBounds};
 
-mod stake_keys;
+mod height_stakes;
 
-use stake_keys::StakeKeys;
+use height_stakes::HeightStakes;
 
 /// Registered stake for a validator
 ///
@@ -22,16 +22,16 @@ pub struct Stake {
     pub value: u64,
 }
 
-/// A stake pool, mapping a validator identity to a set of bft stakes.
+/// A stake pool, mapping a validator identity to a set of height stakes.
 ///
-/// The validator identity is agnostic to this library and the only requirements is it fits in
+/// The validator identity is agnostic to this library and the only requirement is it fits in
 /// [`Bytes64`]
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
-pub struct StakePool {
-    validators: HashMap<Bytes64, StakeKeys>,
+pub struct ValidatorStakes {
+    validators: HashMap<Bytes64, HeightStakes>,
 }
 
-impl StakePool {
+impl ValidatorStakes {
     /// Add a stake that will be valid within the provided height bounds.
     ///
     /// The validator is the permanent identity of the staker, while the stake key is the volatile

--- a/src/stake.rs
+++ b/src/stake.rs
@@ -1,0 +1,103 @@
+use crate::{Error, Height};
+
+use fuel_crypto::PublicKey;
+use fuel_types::Bytes64;
+use hashbrown::HashMap;
+
+use core::ops::{Range, RangeBounds};
+
+mod stake_keys;
+
+use stake_keys::StakeKeys;
+
+/// Registered stake for a validator
+///
+/// The used key might not reflect the canonical validators set and will be used only to verify the
+/// signatures with the chosen protocol.
+#[derive(Default, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Stake {
+    /// One-time key for a height range
+    pub key: PublicKey,
+    /// Staked value
+    pub value: u64,
+}
+
+/// A stake pool, mapping a validator identity to a set of bft stakes.
+///
+/// The validator identity is agnostic to this library and the only requirements is it fits in
+/// [`Bytes64`]
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct StakePool {
+    validators: HashMap<Bytes64, StakeKeys>,
+}
+
+impl StakePool {
+    /// Add a stake that will be valid within the provided height bounds.
+    ///
+    /// The validator is the permanent identity of the staker, while the stake key is the volatile
+    /// per-height key.
+    ///
+    /// If the bounds intersect with an existing stake, they will merged if, and only if, the key
+    /// and value matches. Otherwise, the function will halt with a duplicated stake error.
+    pub fn stake<B>(&mut self, validator: Bytes64, bounds: B, stake: Stake) -> Result<(), Error>
+    where
+        B: RangeBounds<Height>,
+    {
+        self.validators
+            .entry(validator)
+            .or_default()
+            .add_stake_range(bounds, stake)
+    }
+
+    /// Remove all stake entries for the given validator, if present
+    pub fn clear(&mut self, validator: &Bytes64) {
+        if let Some(staked) = self.validators.get_mut(validator) {
+            staked.clear()
+        }
+    }
+
+    /// Return a stake for a given height
+    pub fn fetch(&self, validator: &Bytes64, height: Height) -> Option<&Stake> {
+        self.validators
+            .get(validator)
+            .and_then(|staked| staked.fetch(height))
+    }
+
+    /// Remove all entries that matches the stake key.
+    pub fn purge_key(&mut self, key: &PublicKey) {
+        self.validators
+            .values_mut()
+            .for_each(|staked| staked.purge_key(key));
+    }
+
+    /// Return the total staked value for a given height.
+    pub fn total_staked(&self, height: Height) -> u64 {
+        self.iter()
+            .filter_map(|(_, range, stake)| range.contains(&height).then(|| stake.value))
+            .sum()
+    }
+
+    /// Iter the validator, ranges and stakes
+    pub fn iter(&self) -> impl Iterator<Item = (&Bytes64, &Range<Height>, &Stake)> {
+        self.validators.iter().flat_map(|(validator, staked)| {
+            staked
+                .iter()
+                .map(move |(range, stake)| (validator, range, stake))
+        })
+    }
+
+    /// Attempt to create a keys set from an iterator, calling [`Self::stake`] for each
+    /// item.
+    pub fn try_from_iter<B, T>(iter: T) -> Result<Self, Error>
+    where
+        B: RangeBounds<Height>,
+        T: IntoIterator<Item = (Bytes64, B, Stake)>,
+    {
+        iter.into_iter()
+            .try_fold(Self::default(), |mut pool, (validator, range, stake)| {
+                pool.stake(validator, range, stake)?;
+
+                Ok(pool)
+            })
+    }
+}

--- a/src/stake/stake_keys.rs
+++ b/src/stake/stake_keys.rs
@@ -1,0 +1,170 @@
+use super::Stake;
+use crate::{Error, Height};
+
+use fuel_crypto::PublicKey;
+use hashbrown::HashMap;
+
+use alloc::borrow::ToOwned;
+use core::cmp;
+use core::ops::{Bound, Range, RangeBounds};
+
+#[derive(Default, Debug, Clone, PartialEq, Eq)]
+pub struct StakeKeys {
+    keys: HashMap<Range<Height>, Stake>,
+}
+
+impl StakeKeys {
+    /// The provided key will be used to verify the consensus signatures. It might diverge from the
+    /// constant validator identifier that exists for the canonical stake contract since a key
+    /// rotation strategy is possible.
+    pub(super) fn add_stake_range<B>(&mut self, bounds: B, stake: Stake) -> Result<(), Error>
+    where
+        B: RangeBounds<Height>,
+    {
+        let bounds = normalize_range(bounds);
+
+        // Check if an equivalent stake intersects the arguments - if yes, extend it
+        if let Some(range) = self
+            .keys
+            .iter()
+            .filter(|(_, &staked)| staked == stake)
+            .find_map(|(range, _)| {
+                (range.contains(&bounds.start) || range.contains(&bounds.end)).then(|| range)
+            })
+        {
+            let range = range.to_owned();
+
+            let start = cmp::min(range.start, bounds.start);
+            let end = cmp::max(range.end, bounds.end);
+            let bounds = Range { start, end };
+
+            // Not using the entry manipulation because there is no inherent optimization in doing
+            // that for the cost of manually replacing the hash entry bucket of the key.
+            let _was_removed = self.keys.remove(&range).is_some();
+
+            debug_assert!(_was_removed);
+
+            self.keys.insert(bounds, stake);
+
+            return Ok(());
+        }
+
+        // Extend is not possible because either the key or value differs - intersection is forbidden
+        // from this point
+        if let Some(range) = self
+            .keys
+            .keys()
+            .find(|range| range.contains(&bounds.start) || range.contains(&bounds.end))
+        {
+            return Err(Error::DuplicatedStake {
+                height: range.start,
+                valid_before: range.end,
+            });
+        }
+
+        self.keys.insert(bounds, stake);
+
+        Ok(())
+    }
+
+    /// Remove all stake entries
+    pub(super) fn clear(&mut self) {
+        self.keys.clear();
+    }
+
+    /// Return a stake for a given height
+    pub(super) fn fetch(&self, height: Height) -> Option<&Stake> {
+        self.keys
+            .iter()
+            .filter_map(|(range, stake)| range.contains(&height).then(|| stake))
+            .next()
+    }
+
+    /// Remove all entries with the provided key
+    pub(super) fn purge_key(&mut self, key: &PublicKey) {
+        self.keys.retain(|_, stake| &stake.key != key);
+    }
+
+    /// Iter the ranges and stakes
+    pub(super) fn iter(&self) -> impl Iterator<Item = (&Range<Height>, &Stake)> {
+        self.keys.iter()
+    }
+}
+
+fn normalize_range<R>(bounds: R) -> Range<Height>
+where
+    R: RangeBounds<Height>,
+{
+    let start = match bounds.start_bound() {
+        Bound::Included(s) => *s,
+        Bound::Excluded(s) if s == &Height::MIN => Height::MIN,
+        Bound::Excluded(s) => s.saturating_add(1),
+        Bound::Unbounded => Height::MIN,
+    };
+
+    let end = match bounds.end_bound() {
+        Bound::Included(e) => e.saturating_add(1),
+        Bound::Excluded(e) => *e,
+        Bound::Unbounded => Height::MAX,
+    };
+
+    Range { start, end }
+}
+
+#[test]
+#[cfg(feature = "std")]
+fn stake_keys_intersect_and_merge() {
+    use fuel_crypto::SecretKey;
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
+
+    let rng = &mut StdRng::seed_from_u64(0xbeef);
+
+    // keys
+    let a = SecretKey::random(rng).public_key();
+    let b = SecretKey::random(rng).public_key();
+
+    // values
+    let x = rng.gen();
+    let y = rng.gen();
+
+    let ax = Stake { key: a, value: x };
+    let ay = Stake { key: a, value: y };
+    let by = Stake { key: b, value: y };
+
+    let mut keys = StakeKeys::default();
+    keys.add_stake_range(0..2, ax).expect("no intersect");
+    keys.add_stake_range(3..5, ay).expect("no intersect");
+
+    let mut keys = StakeKeys::default();
+    keys.add_stake_range(0..2, ax).expect("no intersect");
+    keys.add_stake_range(3..5, by).expect("no intersect");
+
+    let mut keys = StakeKeys::default();
+    keys.add_stake_range(0..2, ax).expect("no intersect");
+    keys.add_stake_range(2..4, ay).expect("no intersect");
+
+    let mut keys = StakeKeys::default();
+    keys.add_stake_range(0..2, ax).expect("no intersect");
+    keys.add_stake_range(2..4, by).expect("no intersect");
+
+    let mut keys = StakeKeys::default();
+    keys.add_stake_range(0..2, ax).expect("no intersect");
+    keys.add_stake_range(1..3, ay).err().expect("intersect");
+
+    let mut keys = StakeKeys::default();
+    keys.add_stake_range(1..3, ax).expect("no intersect");
+    keys.add_stake_range(0..2, ay).err().expect("intersect");
+
+    let mut keys = StakeKeys::default();
+    keys.add_stake_range(0..2, ax).expect("no intersect");
+    keys.add_stake_range(1..3, ax).expect("merge");
+    let stake = keys.keys.get(&(0..3)).expect("merged stake");
+    assert_eq!(&Stake { key: a, value: x }, stake);
+
+    let mut keys = StakeKeys::default();
+    keys.add_stake_range(1..3, ax).expect("no intersect");
+    keys.add_stake_range(0..2, ax).expect("merge");
+    let stake = keys.keys.get(&(0..3)).expect("merged stake");
+    assert_eq!(&Stake { key: a, value: x }, stake);
+}


### PR DESCRIPTION
The stake structure will be needed to address #17. We will define the
voting power from the total staked amount for a given height, and
calculate bft out of that.

Two new types were introduced: Stake and StakePool

Stake is a minimalistic representation of a staked value with an
associated consensus key used to verify the round signatures.

StakePool is a mapping from an external validator identifier, constant
per identity, to a set of stakes mapped by block height ranges.